### PR TITLE
Add file output flag

### DIFF
--- a/cs2modrewrite.py
+++ b/cs2modrewrite.py
@@ -18,10 +18,11 @@ parser = argparse.ArgumentParser(description=description)
 parser.add_argument('-i', dest='inputfile', help='C2 Profile file', required=True)
 parser.add_argument('-c', dest='c2server', help='C2 Server (http://teamserver)', required=True)
 parser.add_argument('-r', dest='redirect', help='Redirect to this URL (http://google.com)', required=True)
+parser.add_argument('-o', dest='out_file', help='Write .htaccess contents to target file', required=False)
 
 args = parser.parse_args()
 
-# Make sure we were provided with vaild URLs 
+# Make sure we were provided with vaild URLs
 # https://stackoverflow.com/questions/7160737/python-how-to-validate-a-url-in-python-malformed-or-not
 regex = re.compile(
     r'^(?:http|ftp)s?://' # http:// or https://
@@ -76,7 +77,7 @@ else:
     # i.e. set uri "/path/1 /path/2"
     split_uris = []
     for uri in uris:
-        for i in uri.split():  
+        for i in uri.split():
             split_uris.append(i)
     # Remove any duplicate URIs
     uris = list(set(split_uris))
@@ -89,11 +90,11 @@ uris_string = ".*|".join(uris) + ".*"
 
 htaccess_template = '''
 ########################################
-## .htaccess START 
+## .htaccess START
 RewriteEngine On
 
 ## (Optional)
-## Scripted Web Delivery 
+## Scripted Web Delivery
 ## Uncomment and adjust as needed
 #RewriteCond %{{REQUEST_URI}} ^/css/style1.css?$
 #RewriteCond %{{HTTP_USER_AGENT}} ^$
@@ -127,11 +128,17 @@ print("#### Save the following as .htaccess in the root web directory")
 print("## Profile User-Agent Found:")
 print("# {}".format(ua))
 print("## Profile URIS Found ({}):".format(str(len(uris))))
-for uri in uris: 
+for uri in uris:
     print("# {}".format(uri))
-print(htaccess_template.format(uris=uris_string,ua=ua_string,c2server=args.c2server,redirect=args.redirect))
+
+htaccess = htaccess_template.format(uris=uris_string, ua=ua_string, c2server=args.c2server, redirect=args.redirect)
+if args.out_file:
+    with open(args.out_file, 'w') as outfile:
+        outfile.write(htaccess)
+else:
+    print(htaccess)
 
 
 # Print Errors Found
-if errorfound: 
+if errorfound:
     print(errors, file=sys.stderr)


### PR DESCRIPTION
What do y'all think about adding an output flag? This would be useful when using projects like Ansible with the `command` module. The Ansible `command` module does not allow output to be redirected unless you register the result and use another module for writing to a file. This flag would solve that by performing the execution and write in one execution.