### PR TITLE
Added double quotes to user agent string

### DIFF
--- a/cs2modrewrite.py
+++ b/cs2modrewrite.py
@@ -125,7 +125,7 @@ else:
 ## Default Beacon Staging Support (/1234)
 RewriteCond %{{REQUEST_METHOD}} GET [NC]
 RewriteCond %{{REQUEST_URI}} ^/..../?$
-RewriteCond %{{HTTP_USER_AGENT}} ^({uas})$
+RewriteCond %{{HTTP_USER_AGENT}} "^({uas})$"
 RewriteRule ^.*$ "{c2server}%{{REQUEST_URI}}" [P,L]
 """
     # Replace variables in staging block


### PR DESCRIPTION
The lack of double quotes around the 'Default Beacon Staging Support' user agent string leads to issues when the user agent string contains spaces.